### PR TITLE
let: false position root search uses the actual guess

### DIFF
--- a/src/letSearch/letFinder.py
+++ b/src/letSearch/letFinder.py
@@ -6,6 +6,7 @@ from ..simconfig.simulationConfig import sim_config
 from ..circuit.components import LET
 from .rootSearch.falsePosition import FalsePosition
 from typing import Callable
+
 # TODO: fix annotation
 # from ..variability.predictionServer import PredictionServer
 
@@ -15,10 +16,7 @@ class LetFinder:
     Responsible for finding the minimal LET value from a faulted node to an output.
     """
 
-    def __init__(
-            self,
-            predictor = None, #PredictionServer
-            report: bool = False):
+    def __init__(self, predictor=None, report: bool = False):  # PredictionServer
         """
         Constructor.
 
@@ -175,6 +173,7 @@ class LetFinder:
             root_finder = FalsePosition(
                 f,
                 guess - margin,
+                guess,
                 guess + margin,
                 function_increases,
                 report=self.__report,

--- a/src/letSearch/rootSearch/falsePosition.py
+++ b/src/letSearch/rootSearch/falsePosition.py
@@ -7,6 +7,7 @@ class FalsePosition(RootSearch):
         self,
         f: Callable,
         lower_bound: float,
+        initial_guess: float,
         upper_bound: float,
         increasing: bool,
         x_precision: float = 0.1,
@@ -18,6 +19,7 @@ class FalsePosition(RootSearch):
         super().__init__(f, increasing, iteration_limit, report)
         self.__lower_bound: float = lower_bound
         self.__upper_bound: float = upper_bound
+        self.__inital_guess: float = initial_guess
         self.__x_precision: float = x_precision
         self.__y_precision: float = y_precision
 
@@ -28,9 +30,19 @@ class FalsePosition(RootSearch):
         Returns:
             float: the root
         """
-        x0: float = self.__lower_bound
-        x1: float = self.__upper_bound
+        x0: float = self.__inital_guess
         f0: float = self._f(x0)
+
+        if abs(f0) < self.__y_precision:
+            self._log(
+                f"Initial Guess is Correct:" f"\tcurrent: {x0:.3f}" f"\terror: {f0:.3f}"
+            )
+            return x0
+
+        if (self._increasing and f0 < 0) or (not self._increasing and f0 > 0):
+            x1: float = self.__upper_bound
+        else:
+            x1: float = self.__lower_bound
         f1: float = self._f(x1)
 
         x0, f0, x1, f1 = self.define_bounds(x0, f0, x1, f1)

--- a/src/letSearch/rootSearch/rootSearch.py
+++ b/src/letSearch/rootSearch/rootSearch.py
@@ -29,6 +29,9 @@ class RootSearch(ABC):
             list[float]: bounds
         """
 
+        if x0 > x1:
+            x0, x1, f0, f1 = x1, x0, f1, f0
+
         step = 50
 
         # x1 and x0 in oposite sides


### PR DESCRIPTION
False root position does not actually starts by using the guess, instead it creates bounds around it and try and converge from there. This changes so the guess is actually used.

This changes drastically improves root search. ASAP 7 NAND2 with 2k points was used as a benchmark. Sim per config went from 4.13 to 2.87.