### PR TITLE
Let margin prediction

### DIFF
--- a/src/let/letFinder.py
+++ b/src/let/letFinder.py
@@ -161,20 +161,22 @@ class LetFinder:
             function_increases: bool = let.orient[1] == "rise"
 
             guess: float = None
-            margin: float = None
+            min_margin: float = None
+            max_margin: float = None
             if self.predictor is not None and vars is not None:
-                guess = self.predictor.request_prediction(
+                guess, min_margin, max_margin = self.predictor.request_prediction(
                     let.identity, tuple(vars.values())
                 )
-                margin = 5
             if guess is None:
                 guess = 150
-                margin = 50
+                min_margin = guess - 50
+                max_margin = guess + 50
+
             root_finder = FalsePosition(
                 f,
-                guess - margin,
+                min_margin,
                 guess,
-                guess + margin,
+                max_margin,
                 function_increases,
                 report=self.__report,
             )

--- a/src/let/rootSearch/bissection.py
+++ b/src/let/rootSearch/bissection.py
@@ -45,7 +45,7 @@ class Bissection(RootSearch):
         f0: float = self._f(x0)
         f1: float = self._f(x1)
 
-        x0, f0, x1, f1 = self.define_bounds(x0, f0, x1, f1)
+        x0, f0, x1, f1 = self.define_bounds(x0, f0, x1, f1, 50)
 
         # Actual binary search
         for i in range(self._iteration_limit):

--- a/src/let/rootSearch/falsePosition.py
+++ b/src/let/rootSearch/falsePosition.py
@@ -39,13 +39,15 @@ class FalsePosition(RootSearch):
             )
             return x0
 
+        step: float = x0
         if (self._increasing and f0 < 0) or (not self._increasing and f0 > 0):
             x1: float = self.__upper_bound
         else:
             x1: float = self.__lower_bound
+        step = abs(step - x1)
         f1: float = self._f(x1)
 
-        x0, f0, x1, f1 = self.define_bounds(x0, f0, x1, f1)
+        x0, f0, x1, f1 = self.define_bounds(x0, f0, x1, f1, step)
         self._log("Root in Bounds, False Position Search")
 
         if x0 is None:

--- a/src/let/rootSearch/rootSearch.py
+++ b/src/let/rootSearch/rootSearch.py
@@ -15,7 +15,9 @@ class RootSearch(ABC):
         self._increasing: bool = increasing
         self._iteration_limit: int = iteration_limit
 
-    def define_bounds(self, x0: float, f0: float, x1: float, f1: float) -> float:
+    def define_bounds(
+        self, x0: float, f0: float, x1: float, f1: float, step: float
+    ) -> float:
         """
         Guarantees f0 and f1 are in different sides of the linear zone
 
@@ -24,6 +26,7 @@ class RootSearch(ABC):
             f0 (float): lower bound image
             x1 (float): upper bound
             f1 (float): upper bound image
+            step (float): search step
 
         Returns:
             list[float]: bounds
@@ -31,8 +34,6 @@ class RootSearch(ABC):
 
         if x0 > x1:
             x0, x1, f0, f1 = x1, x0, f1, f0
-
-        step = 50
 
         # x1 and x0 in oposite sides
         if f1 / f0 < 0:
@@ -48,6 +49,8 @@ class RootSearch(ABC):
                 f"\tupper border: x={x1:.1f} y={f1:.3f}"
             )
 
+            step *= 2
+
             if (self._increasing and f0 > 0) or (not self._increasing and f0 < 0):
                 x1, f1 = x0, f0
                 x0 -= step
@@ -59,8 +62,6 @@ class RootSearch(ABC):
                 x1 += step
                 x1 = max(0, x1)
                 f1 = self._f(x1)
-
-            step *= 2
 
             # x1 and x0 in oposite sides
             if f1 / f0 < 0:

--- a/src/var/prediction/averagePredictor.py
+++ b/src/var/prediction/averagePredictor.py
@@ -13,13 +13,21 @@ class AveragePredictor(AbstractPredictor):
     def __init__(self):
         self.points = 0
         self.average = 0
+        self._max = 0
+        self._min = None
 
     def add_data(self, var: tuple, current: float) -> None:
         self.average = self.average * self.points + current
         self.points += 1
         self.average /= self.points
+        self._max = max(self._max, current)
+        if self._min is None:
+            self._min = current
+        else:
+            self._min = min(self._min, current)
+        self.range = 5 if self.points < 10 else (self._max - self._min) * 0.05
 
-    def predict(self, var):
+    def predict(self, var) -> tuple:
         if not self.points:
             return None
-        return self.average
+        return self.average, self.average - self.range, self.average + self.range

--- a/src/var/prediction/knnRegPredictor.py
+++ b/src/var/prediction/knnRegPredictor.py
@@ -41,11 +41,19 @@ class KnnRegPredictor(AbstractPredictor):
         self._outputs = []
         self._model = None
         self._new_points = 0
+        self._max = 0
+        self._min = None
 
     def add_data(self, var: tuple, current: float) -> None:
         self._new_points += 1
         self._inputs.append(var)
         self._outputs.append(current)
+        self._max = max(self._max, current)
+        if self._min is None:
+            self._min = current
+        else:
+            self._min = min(self._min, current)
+        self.range = 5 if self._new_points < 10 else (self._max - self._min) * 0.05
 
     @property
     def model(self):
@@ -66,5 +74,6 @@ class KnnRegPredictor(AbstractPredictor):
     def predict(self, var: tuple) -> float:
         model = self.model
         if model is None:
-            return None
-        return model.predict([var])[0]
+            return None, None, None
+        prediction: float = model.predict([var])[0]
+        return prediction, prediction - self.range, prediction + self.range


### PR DESCRIPTION
shuffles let evaluation order when updating circuit profile for marginal, but cheap, gains

includes a rudimentary support for the predictor to return a margin in which it thinks the result lies in. Starts with 5 in all cases, which was the case before, and after the model has 10 points simply uses 5% of the total range of current values in the model.